### PR TITLE
fix getFormTemplate function 

### DIFF
--- a/Element/QueryBuilderElement.php
+++ b/Element/QueryBuilderElement.php
@@ -73,7 +73,7 @@ class QueryBuilderElement extends BaseElement
      */
     public static function getFormTemplate()
     {
-        return 'QueryBuilderBundle:ElementAdmin:queryBuilder.html.twig';
+        return 'MapbenderQueryBuilderBundle:ElementAdmin:queryBuilder.html.twig';
     }
 
     public function getFrontendTemplatePath($suffix = '.html.twig')


### PR DESCRIPTION
In the QueryBuilder element, the admin backend twig was no longer rendered because an incorrect namespace was referenced. This bug has been fixed.